### PR TITLE
Tracking user messages and summarizing conversations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ KLIPY_API_KEY=  # Get from https://partner.klipy.com/api-keys
 # AI Features (Optional)
 GOOGLE_GENERATIVE_AI_API_KEY=  # Get from Google AI Studio
 DEEPL=           # Get from DeepL API (for translation features)
+AI_SUMMARY_WINDOW=50  # Messages kept verbatim before older history is compacted into a summary (0 = disable)
 
 # Role System (Optional)
 # Use exact role names (comma separated) that exist in your Discord server

--- a/src/core/handlers/event-handlers/ai-chat.handler.ts
+++ b/src/core/handlers/event-handlers/ai-chat.handler.ts
@@ -1,6 +1,6 @@
 import { AiChatService } from "@/core/services/ai/ai-chat.service";
 import { PrivacyService } from "@/core/services/privacy/privacy.service";
-import { AI_TOOLS, CODING_GLOBAL_PATTERN } from "@/shared/ai/ai-tools";
+import { createAiTools, CODING_GLOBAL_PATTERN } from "@/shared/ai/ai-tools";
 import { ConfigValidator } from "@/shared/config/validator";
 import { error } from "console";
 import { Message, MessageFlags, TextChannel } from "discord.js";
@@ -37,7 +37,10 @@ export async function handleAiChatMessage(
   }
 
   try {
-    const response = await AiChatService.generateResponse(message, AI_TOOLS);
+    const response = await AiChatService.generateResponse(
+      message,
+      createAiTools(message.author.id),
+    );
 
     if (!response || (!response.text && !response.gifUrl)) return;
 

--- a/src/core/services/ai/ai-chat.service.ts
+++ b/src/core/services/ai/ai-chat.service.ts
@@ -11,14 +11,33 @@ import { LRUCache } from "lru-cache";
 import { AiContextService } from "./ai-context.service";
 import type { AiChatResponse } from "@/types";
 
-const channelMessages = new LRUCache<string, ModelMessage[]>({ max: 1000 });
+const channelMessages = new LRUCache<string, ModelMessage[]>({
+  max: 1000,
+  dispose: (_, channelId) => channelSummaries.delete(channelId),
+});
+const channelSummaries = new LRUCache<string, string>({ max: 1000 });
+
+// Number of recent messages kept verbatim before the older tail is compacted
+// into a running summary. Configurable via AI_SUMMARY_WINDOW (default 50).
+// Set to 0 to disable summarization entirely.
+const SUMMARY_WINDOW = (() => {
+  const parsed = Number(process.env.AI_SUMMARY_WINDOW);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 50;
+})();
+
+const SUMMARY_SYSTEM_PROMPT = `You are condensing a Discord chat history into a concise running summary.
+Rules:
+- User messages are prefixed with [Name]: — preserve these prefixes exactly so it is clear who said what.
+- Bot (assistant) messages have NO prefix — represent them as the bot's own responses.
+- Keep it concise but retain key facts, questions, decisions, and who said them.
+- Do not invent information not present in the messages.`;
 
 export class AiChatService {
   static async generateResponse(
     message: Message,
     tools: Record<string, any>,
   ): Promise<AiChatResponse | null> {
-    const userMsg = this.extractUserMessage(message);
+    const userMsg = `[${message.author.displayName}]: ${this.extractUserMessage(message)}`;
     const { replyContext, repliedImages } =
       await AiContextService.getReplyContext(message);
 
@@ -43,12 +62,26 @@ export class AiChatService {
     const messages = channelMessages.get(message.channel.id) || [];
     messages.push(userMessage);
 
+    // Compact older history into a running summary once it exceeds the window.
+    await this.compactHistory(message.channel.id, messages);
+
+    const summary = channelSummaries.get(message.channel.id);
+    const contextMessages: ModelMessage[] = summary
+      ? [
+          {
+            role: "system",
+            content: `Previous conversation summary:\n${summary}`,
+          },
+          ...messages,
+        ]
+      : [...messages];
+
     const runAI = async () => {
       return googleClient.executeWithRotation(async (model) => {
         return generateText({
           model,
           system: CHAT_SYSTEM_PROMPT,
-          messages: [...messages],
+          messages: contextMessages,
           tools,
           stopWhen: stepCountIs(3),
           maxOutputTokens: 1024,
@@ -105,6 +138,68 @@ export class AiChatService {
       .replace(mentionPattern, "")
       .replace(codingGlobalPattern, "")
       .trim();
+  }
+
+  private static async compactHistory(
+    channelId: string,
+    messages: ModelMessage[],
+  ): Promise<void> {
+    if (messages.length <= SUMMARY_WINDOW) return;
+
+    const tail = messages.slice(0, messages.length - SUMMARY_WINDOW);
+    const kept = messages.slice(messages.length - SUMMARY_WINDOW);
+    const previousSummary = channelSummaries.get(channelId);
+
+    const tailText = tail
+      .map((msg) => {
+        const content = Array.isArray(msg.content)
+          ? msg.content
+              .filter(
+                (p): p is { type: "text"; text: string } =>
+                  p.type === "text",
+              )
+              .map((p) => p.text)
+              .join(" ")
+          : msg.content;
+        const prefix =
+          msg.role === "assistant" ? "[Bot]: " : "";
+        return `${prefix}${content}`;
+      })
+      .join("\n");
+
+    const existingSummaryLine = previousSummary
+      ? `Existing summary:\n${previousSummary}\n\n`
+      : "";
+
+    try {
+      const result = await googleClient.executeWithRotation(async (model) =>
+        generateText({
+          model,
+          system: SUMMARY_SYSTEM_PROMPT,
+          messages: [
+            {
+              role: "user",
+              content: `${existingSummaryLine}New messages to incorporate:\n${tailText}\n\nReturn the updated, concise running summary.`,
+            },
+          ],
+          maxOutputTokens: 1024,
+          maxRetries: 0,
+        }),
+      );
+
+      const updated = result?.text?.trim();
+      if (updated) {
+        channelSummaries.set(channelId, updated);
+        // Replace the full history with just the recent window.
+        messages.length = 0;
+        messages.push(...kept);
+        channelMessages.set(channelId, messages);
+      }
+    } catch (error) {
+      botLogger.error("Failed to compact chat history", {
+        error: String(error),
+      });
+    }
   }
 
   private static buildUserMessage(

--- a/src/shared/ai/ai-tools.ts
+++ b/src/shared/ai/ai-tools.ts
@@ -1,5 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod/v4";
+import { GuildChannel, PermissionFlagsBits } from "discord.js";
 import { botLogger } from "@/lib/telemetry";
 import { ConfigValidator } from "@/shared/config/validator";
 import { StatsService } from "@/core/services/stats/stats.service";
@@ -45,96 +46,119 @@ async function searchGifs(query: string, limit: number = 5): Promise<string[]> {
   }
 }
 
-export const gatherChannelContext = tool({
-  description:
-    "Gather recent messages and user context from a specific channel when you need more conversation history to provide better responses.",
-  inputSchema: z.object({
-    channelId: z
-      .string()
-      .describe("The Discord channel ID to fetch messages from"),
-    guildId: z.string().describe("The Discord guild/server ID"),
-    messageCount: z
-      .number()
-      .min(1)
-      .max(50)
-      .default(10)
-      .describe("Number of recent messages to fetch (1-50)"),
-  }),
-  execute: async ({ channelId, guildId, messageCount }) => {
-    try {
-      botLogger.info("Gathering AI context", { channelId, guildId });
-      const guild = await bot.guilds.fetch(guildId).catch(() => null);
-      if (!guild) {
-        return { success: false, error: "Guild not found" };
-      }
-
-      const channel = await guild.channels.fetch(channelId).catch(() => null);
-      if (!channel || !channel.isTextBased()) {
-        return { success: false, error: "Channel not found or not text-based" };
-      }
-
-      const messages = await channel.messages.fetch({ limit: messageCount });
-      const sortedMessages = Array.from(messages.values())
-        .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
-        .filter((msg) => !msg.author.bot);
-
-      const userContexts = new Map<string, any>();
-      const messageContexts = [];
-
-      for (const message of sortedMessages) {
-        if (!userContexts.has(message.author.id)) {
-          try {
-            const userStats = await StatsService.getUserStatsEmbed(
-              message.author.id,
-              guildId,
-            );
-            userContexts.set(message.author.id, userStats);
-          } catch {
-            userContexts.set(message.author.id, null);
-          }
+function createGatherChannelContext(requestingUserId: string) {
+  return tool({
+    description:
+      "Gather recent messages and user context from a specific channel when you need more conversation history to provide better responses. You can only access channels that the requesting user is permitted to read.",
+    inputSchema: z.object({
+      channelId: z
+        .string()
+        .describe("The Discord channel ID to fetch messages from"),
+      guildId: z.string().describe("The Discord guild/server ID"),
+      messageCount: z
+        .number()
+        .min(1)
+        .max(50)
+        .default(10)
+        .describe("Number of recent messages to fetch (1-50)"),
+    }),
+    execute: async ({ channelId, guildId, messageCount }) => {
+      try {
+        botLogger.info("Gathering AI context", {
+          channelId,
+          guildId,
+          requestingUserId,
+        });
+        const guild = await bot.guilds.fetch(guildId).catch(() => null);
+        if (!guild) {
+          return { success: false, error: "Guild not found" };
         }
 
-        const userContext = userContexts.get(message.author.id);
+        const channel = await guild.channels.fetch(channelId).catch(() => null);
+        if (!channel || !channel.isTextBased()) {
+          return {
+            success: false,
+            error: "Channel not found or not text-based",
+          };
+        }
 
-        messageContexts.push({
-          timestamp: message.createdAt.toISOString(),
-          author: {
-            id: message.author.id,
-            username: message.author.username,
-            displayName: message.author.globalName,
-            stats: userContext
-              ? {
-                  roles: userContext.roles?.filter(Boolean) || [],
-                  messageCount:
-                    userContext.embed?.fields?.[0]?.value || "Unknown",
-                  voiceTime: userContext.embed?.fields?.[1]?.value || "Unknown",
-                }
-              : null,
+        // Permission check: only allow channels the requesting user can read.
+        const permissions = (channel as GuildChannel).permissionsFor(
+          requestingUserId,
+        );
+        if (!permissions?.has(PermissionFlagsBits.ReadMessageHistory)) {
+          return {
+            success: false,
+            error: "You do not have permission to read messages in this channel",
+          };
+        }
+
+        const messages = await channel.messages.fetch({ limit: messageCount });
+        const sortedMessages = Array.from(messages.values())
+          .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+          .filter((msg) => !msg.author.bot);
+
+        const userContexts = new Map<string, any>();
+        const messageContexts = [];
+
+        for (const message of sortedMessages) {
+          if (!userContexts.has(message.author.id)) {
+            try {
+              const userStats = await StatsService.getUserStatsEmbed(
+                message.author.id,
+                guildId,
+              );
+              userContexts.set(message.author.id, userStats);
+            } catch {
+              userContexts.set(message.author.id, null);
+            }
+          }
+
+          const userContext = userContexts.get(message.author.id);
+
+          messageContexts.push({
+            timestamp: message.createdAt.toISOString(),
+            author: {
+              id: message.author.id,
+              username: message.author.username,
+              displayName: message.author.globalName,
+              stats: userContext
+                ? {
+                    roles: userContext.roles?.filter(Boolean) || [],
+                    messageCount:
+                      userContext.embed?.fields?.[0]?.value || "Unknown",
+                    voiceTime:
+                      userContext.embed?.fields?.[1]?.value || "Unknown",
+                  }
+                : null,
+            },
+            content: message.content,
+            hasAttachments: message.attachments.size > 0,
+            isReply: !!message.reference,
+            replyToId: message.reference?.messageId,
+          });
+        }
+
+        return {
+          success: true,
+          context: {
+            messageCount: messageContexts.length,
+            messages: messageContexts,
+            fetchedAt: new Date().toISOString(),
           },
-          content: message.content,
-          hasAttachments: message.attachments.size > 0,
-          isReply: !!message.reference,
-          replyToId: message.reference?.messageId,
+        };
+      } catch (error) {
+        botLogger.error("Error gathering channel context", {
+          error: String(error),
         });
+        return {
+          success: false,
+          error: `Failed to gather channel context: ${error instanceof Error ? error.message : "Unknown error"}`,
+        };
       }
-
-      return {
-        success: true,
-        context: {
-          messageCount: messageContexts.length,
-          messages: messageContexts,
-          fetchedAt: new Date().toISOString(),
-        },
-      };
-    } catch (error) {
-      botLogger.error("Error gathering channel context", { error: String(error) });
-      return {
-        success: false,
-        error: `Failed to gather channel context: ${error instanceof Error ? error.message : "Unknown error"}`,
-      };
-    }
-  },
-});
+    },
+  });
+}
 
 export const searchMemeGifs = tool({
   description:
@@ -165,4 +189,9 @@ export const searchMemeGifs = tool({
 
 export const CODING_GLOBAL_PATTERN = /^coding\s?global/i;
 
-export const AI_TOOLS = { searchMemeGifs, gatherChannelContext };
+export function createAiTools(requestingUserId: string) {
+  return {
+    searchMemeGifs,
+    gatherChannelContext: createGatherChannelContext(requestingUserId),
+  };
+}


### PR DESCRIPTION
Bot is now using a prefix each user turn in chat memory with [Name] so the model knows who said what.
Added rolling window summarization, once a channels history exeeds the AI_SUMMARY_WINDOW in the .env the older tail is summarized, The summary preserves [Name].
Also tied the channelMessages and summaries caches together